### PR TITLE
update to feature layer tooltip sample

### DIFF
--- a/web/src/FeatureLayerWithTooltips.mxml
+++ b/web/src/FeatureLayerWithTooltips.mxml
@@ -45,8 +45,12 @@
                 event.graphic.toolTip = event.graphic.attributes.Name + "\n";
                 event.graphic.toolTip += "Magnitude " + myOneDecimalFormatter.format(event.graphic.attributes.Magnitude) + " earthquake";
                 if (event.graphic.attributes.Num_Deaths)
-                {
-                    event.graphic.toolTip += "\n(" + event.graphic.attributes.Num_Deaths + " people died)";
+                {                    
+					if (event.graphic.attributes.Num_Deaths == 1) {
+					    event.graphic.toolTip += "\n(" + event.graphic.attributes.Num_Deaths + " person died)";
+					}
+					else
+					    event.graphic.toolTip += "\n(" + event.graphic.attributes.Num_Deaths + " people died)";
                 }
             }
         ]]>


### PR DESCRIPTION
just added a check to ensure that "person" is substituted for "people" in situtations where an earthquake only resulted in one death.
