### PR TITLE
Update ArcGISHeatMapLayer(solve a bug)

### DIFF
--- a/web/src/com/esri/ags/samples/layers/ArcGISHeatMapLayer.as
+++ b/web/src/com/esri/ags/samples/layers/ArcGISHeatMapLayer.as
@@ -167,6 +167,8 @@ public class ArcGISHeatMapLayer extends Layer
     private var _featureIndexCalculator:Function = internalFeatureCalculator;
     private var _clusterIndexCalculator:Function = internalClusterCalculator;
     private var _clusterWeightCalculator:Function = internalWeightCalculator;
+    
+    private var flagupdate:Boolean=false;
 
     /**
      * Creates a new ArcGISHeatMapLayer object.
@@ -235,6 +237,7 @@ public class ArcGISHeatMapLayer extends Layer
             _detailsTask.addEventListener(FaultEvent.FAULT, getDetailsFaultHandler, false, 0, true);
             _detailsTask.getDetails(layerID);
         }
+        flagupdate=true;
     }
 
     /**
@@ -268,6 +271,11 @@ public class ArcGISHeatMapLayer extends Layer
     {
         if (map && map.extent)
         {
+        if(flagupdate==false)
+			{
+				var tagEvent:LayerEvent=new LayerEvent(LayerEvent.UPDATE_START,this);
+				updateStartCompleteHandler(tagEvent);
+			}
             generateHeatMap(map.extent);
         }
     }


### PR DESCRIPTION
Maybe my English is not so good ,but please read this carefully,I think I have found a bug and have already solved it.

I found that if we define heatmaplayer unvisiable in the mxml doc,and then make it visiable to show some "timeextent" data in some function(such as a button clicked message function),this would happen:
first,function:generateHeatMap will run,which includes" _heatMapQueryTask.useAMF = _useAMF;"but the var "_heatMapQueryTask" equals "null" so it courses a bug. Why? "heatMapQueryTask"  will be evaluated in the function "updateStartCompleteHandler".but  "updateStartCompleteHandler" will trigger later than "generateHeatMap "
"generateHeatMap " triggers when heatmaplyer's "where"/"timeextent"/“url” changes, so I use a flag to solve this.If "updateStartCompleteHandler" has already trrigered before "generateHeatMap ",everything will go just the same way,otherwise we run the "updateStartCompleteHandler" once to  assign  value to the parameters before the "generateHeatMap " .

I have changed three places in the as doc
1:add a private var flagupdate(used to check if the "updateStartCompleteHandler" had been executed )
2. In the "updateStartCompleteHandler" function ,add "flagupdate=true";
3. In the function "invalidateHeatMap" function ,add 
                        if(flagupdate==false)
            {
                var tagEvent:LayerEvent=new LayerEvent(LayerEvent.UPDATE_START,this);
                updateStartCompleteHandler(tagEvent);
            }

before "generateHeatMap " .

Thanks for your time. 
